### PR TITLE
modify to show the correct doc title

### DIFF
--- a/docs/01-intro.md
+++ b/docs/01-intro.md
@@ -1,13 +1,13 @@
 ---
 sidebar_position: 1
 slug: /
+title: Introduction
 ---
+
 <!-- This meta tag needs to be added to the root page -->
 <head>
     <meta name="google-site-verification" content="WOO3lZv61a34McG2UBDokssGzsFQ8f-y8INVMqPAhr0" />
 </head>
-
-# Introduction
 
 Cross Framework enables the development of cross-chain smart contracts that reference data and perform functions distributed across multiple Blockchains.
 


### PR DESCRIPTION
I don't know how to maintain the title in the markdown header while [giving `head` tag](https://61716a75858b7d0007e84c89--docusaurus-2.netlify.app/docs/2.0.0-beta.6/markdown-features/head-metadatas
), so I solved this problem by explicitly specifying the title in the meta information.

Signed-off-by: Ryo Sato <ryo.sato@datachain.jp>